### PR TITLE
chore: fix pypi badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Magic Hour Python SDK
 
-![PyPI - Version](https://img.shields.io/pypi/v/magic_hour)
+[![PyPI - Version](https://img.shields.io/pypi/v/magic_hour)](https://pypi.org/project/magic_hour/)
 
 Magic Hour provides an API (beta) that can be integrated into your own application to generate videos and images using AI.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix PyPI badge link in `README.md` to be clickable and direct to the correct project page.
> 
>   - **Documentation**:
>     - Fix PyPI badge link in `README.md` to be clickable, directing to the correct PyPI project page for `magic_hour`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=magichourhq%2Fmagic-hour-python&utm_source=github&utm_medium=referral)<sup> for caf0bee36050e3ee6f06d114371e327dbc8a3eb0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->