### PR TITLE
fix: add official SDK package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,29 @@
 [tool.poetry]
 name = "magic_hour"
-version = "0.75.2"
+version = "0.75.3"
 description = "Python SDK for Magic Hour API"
 readme = "README.md"
 authors = []
 packages = [{ include = "magic_hour" }]
+homepage = "https://magichour.ai"
+repository = "https://github.com/magichourhq/magic-hour-python"
+documentation = "https://docs.magichour.ai"
+keywords = [
+    "magic-hour",
+    "generative-ai",
+    "ai-video",
+    "ai-image",
+    "ai-audio",
+    "video-generation",
+    "image-generation",
+    "audio-generation",
+    "text-to-video",
+    "image-to-video",
+    "face-swap",
+    "lip-sync",
+    "sdk",
+    "api",
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
## Summary

- add official homepage, repository, and documentation URLs to PyPI metadata
- add focused keywords for video, image, and audio generation use cases
- bump the package version from 0.75.2 to 0.75.3

## Why

The published PyPI package has no project URLs or capability keywords, so developers and automated tools cannot verify its official source, navigate directly to documentation, or identify its supported AI media use cases from package metadata.

## Developer impact

After 0.75.3 is published, PyPI will display direct Homepage, Repository, and Documentation links plus machine-readable capability keywords.

## Validation

- `poetry check`
- `poetry run pytest --ignore=local_test.py` — 161 tests passed
- `poetry build` — wheel and sdist built successfully
- inspected wheel METADATA and confirmed Project-URL and Keywords entries
- all configured URLs returned HTTP 200
