### PR TITLE
docs: fix commas in image generation workflow examples

### DIFF
--- a/magic_hour/resources/v1/ai_headshot_generator/README.md
+++ b/magic_hour/resources/v1/ai_headshot_generator/README.md
@@ -32,7 +32,7 @@ from os import getenv
 
 client = Client(token=getenv("API_TOKEN"))
 res = client.v1.ai_headshot_generator.generate(
-    assets={"image_file_path": "/path/to/1234.png"}, name="Ai Headshot image"
+    assets={"image_file_path": "/path/to/1234.png"}, name="Ai Headshot image",
     wait_for_completion=True,
     download_outputs=True,
     download_directory="."
@@ -47,7 +47,7 @@ from os import getenv
 
 client = AsyncClient(token=getenv("API_TOKEN"))
 res = await client.v1.ai_headshot_generator.generate(
-    assets={"image_file_path": "/path/to/1234.png"}, name="Ai Headshot image"
+    assets={"image_file_path": "/path/to/1234.png"}, name="Ai Headshot image",
     wait_for_completion=True,
     download_outputs=True,
     download_directory="."

--- a/magic_hour/resources/v1/photo_colorizer/README.md
+++ b/magic_hour/resources/v1/photo_colorizer/README.md
@@ -32,7 +32,7 @@ from os import getenv
 
 client = Client(token=getenv("API_TOKEN"))
 res = client.v1.photo_colorizer.generate(
-    assets={"image_file_path": "/path/to/1234.png"}, name="Photo Colorizer image"
+    assets={"image_file_path": "/path/to/1234.png"}, name="Photo Colorizer image",
     wait_for_completion=True,
     download_outputs=True,
     download_directory="."
@@ -47,7 +47,7 @@ from os import getenv
 
 client = AsyncClient(token=getenv("API_TOKEN"))
 res = await client.v1.photo_colorizer.generate(
-    assets={"image_file_path": "/path/to/1234.png"}, name="Photo Colorizer image"
+    assets={"image_file_path": "/path/to/1234.png"}, name="Photo Colorizer image",
     wait_for_completion=True,
     download_outputs=True,
     download_directory="."


### PR DESCRIPTION
The synchronous and asynchronous Headshot Generator and Photo Colorizer examples omit the comma before `wait_for_completion`, so copying them raises a Python syntax error. Add the four missing commas in the custom documentation sections.

These README examples are also consumed by web-app code-sample generation and the published API reference. The docs acquisition audit in https://github.com/magichourhq/docs/pull/499 corrects the current reference snapshot; after this source fix is merged, run the existing code-sample sync and publish the refreshed OpenAPI data so subsequent docs syncs retain it. The generator already adds the required separator; no generator or runtime changes are needed.

Validation: all 174 Python fenced snippets across SDK READMEs parse with `ast.parse`; `git diff --check` passes. This checks syntax only; no API generation or release was performed.
